### PR TITLE
デフォルトのお酒追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,8 +8,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user)
+      @user.create_default_drinks
       NotificationSetting.create(user_id: @user.id)
-      redirect_to login_path, success: t('.success')
+      redirect_to records_path, success: t('.success')
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,39 @@ class User < ApplicationRecord
     .where(records: { date: Date.yesterday.beginning_of_month + 9.hours..Date.yesterday.end_of_month + 1 + 9.hours })
   end
 
+
+  def create_default_drinks
+    drinks.create([
+      # ビール
+      { name: '350ml缶', volume: 350, degree: 5, category_id: 1 },
+      { name: '500ml缶', volume: 500, degree: 5, category_id: 1 },
+      { name: '中ジョッキ', volume: 400, degree: 5, category_id: 1 },
+      # ワイン
+      { name: 'グラス', volume: 120, degree: 12, category_id: 2 },
+      { name: 'ボトル', volume: 720, degree: 12, category_id: 2 },
+      # 日本酒
+      { name: '一合', volume: 180 , degree: 15, category_id: 3 },
+      # 焼酎
+      { name: 'ロック', volume: 80, degree: 25, category_id: 4 },
+      { name: '水割り', volume: 180, degree: 15, category_id: 4 },
+      # ウイスキー
+      { name: 'ロック', volume: 30, degree: 43, category_id: 5 },
+      # ハイボール
+      { name: '350ml缶', volume: 350, degree: 7, category_id: 6 },
+      { name: '500ml缶', volume: 500, degree: 7, category_id: 6 },
+      { name: '中ジョッキ', volume: 400, degree: 7, category_id: 6 },
+      # 酎ハイ
+      { name: '350ml缶', volume: 350, degree: 5, category_id: 7 },
+      { name: '500ml缶', volume: 500, degree: 5, category_id: 7 },
+      # サワー
+      { name: 'グラス', volume: 300, degree: 5, category_id: 8 },
+      # ジン
+      { name: 'ロック', volume: 30, degree: 40, category_id: 9 },
+      # ウォッカ
+      { name: 'ロック', volume: 30, degree: 40, category_id: 10 },
+      # 果実酒
+      { name: 'グラス', volume: 120, degree: 8, category_id: 11 },
+    ])
+  end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,10 +14,6 @@ Category.create(
 )
 
 Category.create(
-  name: "カクテル"
-)
-
-Category.create(
   name: "日本酒"
 )
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Users", type: :system do
           fill_in "パスワード", with: "password"
           fill_in "パスワード確認", with: "password"
           click_button "登録"
-          expect(page).to have_current_path(login_path)
+          expect(page).to have_current_path(records_path)
           expect(page).to have_content "登録に成功しました"
         end
       end


### PR DESCRIPTION
close #57 

新規登録後に、お酒の初期データが作成されるように変更
新規登録後、自動でログインするように変更
ログイン後、飲酒記録登録画面にリダイレクトするように、変更

